### PR TITLE
add history_type to trajctory dataset

### DIFF
--- a/test/test_deepmove.py
+++ b/test/test_deepmove.py
@@ -32,7 +32,8 @@ config = {
     "hidden_size": 500,
     "attn_type": "dot",
     "rnn_type": "LSTM",
-    "dropout_p": 0.3
+    "dropout_p": 0.3,
+    'history_type': 'cut_off'
 }
 
 config['dataset'] = 'foursquare_tky' # foursquare_tky

--- a/trafficdl/config/data/trajectory_dataset.json
+++ b/trafficdl/config/data/trajectory_dataset.json
@@ -7,5 +7,6 @@
     "num_workers": 0,
     "cache_dataset": true,
     "train_rate": 0.6,
-    "eval_rate": 0.2
+    "eval_rate": 0.2,
+    "history_type": "splice"
 }

--- a/trafficdl/data/batch.py
+++ b/trafficdl/data/batch.py
@@ -73,6 +73,10 @@ class Batch(object):
                     self.data[key] = torch.LongTensor(self.data[key]).cuda()
                 elif self.feature_name[key] == 'float':
                     self.data[key] = torch.FloatTensor(self.data[key]).cuda()
+                elif self.feature_name[key] == 'array of int':
+                    for i in range(len(self.data[key])):
+                        for j in range(len(self.data[key][i])):
+                            self.data[key][i][j] = torch.LongTensor(self.data[key][i][j]).cuda()
                 else:
                     raise TypeError('Batch to_tensor, only support int or float, and you give {}'.format(self.feature_name[key]))
             else:
@@ -80,5 +84,9 @@ class Batch(object):
                     self.data[key] = torch.LongTensor(self.data[key])
                 elif self.feature_name[key] == 'float':
                     self.data[key] = torch.FloatTensor(self.data[key])
+                elif self.feature_name[key] == 'array of int':
+                    for i in range(len(self.data[key])):
+                        for j in range(len(self.data[key][i])):
+                            self.data[key][i][j] = torch.LongTensor(self.data[key][i][j])
                 else:
                     raise TypeError('Batch to_tensor, only support int or float, and you give {}'.format(self.feature_name[key]))


### PR DESCRIPTION
* Trajectory Dataset 关于历史轨迹提供两种输入格式
* `splice`: 拼接模式，将多段历史轨迹拼接成一条长的历史轨迹（默认模式）。
* `cut_off`: 剪接模视，不对多段历史轨迹进行拼接直接放在一个数组里面输入给模型。（此模式不支持 batch 操作）