### PR TITLE
fix dataset name

### DIFF
--- a/libcity/data/dataset/dataset_subclass/pbs_trajectory_dataset.py
+++ b/libcity/data/dataset/dataset_subclass/pbs_trajectory_dataset.py
@@ -20,7 +20,10 @@ class PBSTrajectoryDataset(AbstractDataset):
     def __init__(self, config):
         self.config = config
         self.cache_file_folder = './libcity/cache/dataset_cache/'
-        self.data_path = './raw_data/{}/'.format(self.config['dataset'])
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.dyna_file = self.config.get('dyna_file', self.dataset)
+        self.data_path = './raw_data/{}/'.format(self.dataset)
         self.data = None
         # 加载 encoder
         self.encoder = self.get_encoder()
@@ -86,7 +89,7 @@ class PBSTrajectoryDataset(AbstractDataset):
         """
         # load data according to config
         traj = pd.read_csv(os.path.join(
-            self.data_path, '{}.dyna'.format(self.config['dataset'])))
+            self.data_path, '{}.dyna'.format(self.dyna_file)))
         # filter inactive poi
         group_location = traj.groupby('location').count()
         filter_location = group_location[group_location['time'] > self.config['min_checkins']]

--- a/libcity/data/dataset/eta_dataset.py
+++ b/libcity/data/dataset/eta_dataset.py
@@ -27,7 +27,10 @@ class ETADataset(AbstractDataset):
             for param in parameter_list_cut:
                 self.cut_data_cache += '_' + str(self.config[param])
             self.cut_data_cache += '.json'
-        self.data_path = './raw_data/{}/'.format(self.config['dataset'])
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.dyna_file = self.config.get('dyna_file', self.dataset)
+        self.data_path = './raw_data/{}/'.format(self.dataset)
         self.data = None
         self._logger = getLogger()
         # 加载 encoder
@@ -63,8 +66,8 @@ class ETADataset(AbstractDataset):
         """
         # load data according to config
         dyna_file = pd.read_csv(os.path.join(
-            self.data_path, '{}.dyna'.format(self.config['dataset'])))
-        self._logger.info("Loaded file " + self.config['dataset'] + '.dyna, shape=' + str(dyna_file.shape))
+            self.data_path, '{}.dyna'.format(self.dyna_file)))
+        self._logger.info("Loaded file " + self.dyna_file + '.dyna, shape=' + str(dyna_file.shape))
         self.dyna_feature_column = {col: i for i, col in enumerate(dyna_file)}
         res = dict()
         if self.need_cut:
@@ -261,7 +264,7 @@ class ETADataset(AbstractDataset):
                 self._logger.info("Dataset created")
                 if self.need_cut and os.path.exists(self.cut_data_cache):
                     dyna_file = pd.read_csv(os.path.join(
-                        self.data_path, '{}.dyna'.format(self.config['dataset'])))
+                        self.data_path, '{}.dyna'.format(self.dyna_file)))
                     self.dyna_feature_column = {col: i for i, col in enumerate(dyna_file)}
                     f = open(self.cut_data_cache, 'r')
                     dyna_data = json.load(f)

--- a/libcity/data/dataset/eta_encoder/ttpnet_encoder.py
+++ b/libcity/data/dataset/eta_encoder/ttpnet_encoder.py
@@ -59,9 +59,13 @@ class TtpnetEncoder(AbstractETAEncoder):
             './libcity/cache/dataset_cache/', 'eta{}.json'.format(parameters_str))
 
         self.geo_embedding = []
-        path = "./raw_data/{}/{}.geo".format(config['dataset'], config['dataset'])
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.rel_file = self.config.get('rel_file', self.dataset)
+        self.dyna_file = self.config.get('dyna_file', self.dataset)
+        path = "./raw_data/{}/{}.geo".format(self.dataset, self.geo_file)
         f_geo = pd.read_csv(path)
-        self._logger.info("Loaded file " + self.config['dataset'] + '.geo')
+        self._logger.info("Loaded file " + self.geo_file + '.geo')
         for row in f_geo.itertuples():
             embedding = eval(getattr(row, 'embeddings'))
             self.geo_embedding.append(embedding[:])

--- a/libcity/data/dataset/traffic_state_datatset.py
+++ b/libcity/data/dataset/traffic_state_datatset.py
@@ -369,16 +369,16 @@ class TrafficStateDataset(AbstractDataset):
 
     def _load_od_4d(self, filename):
         """
-                加载.od文件，格式[dyna_id, type, time, origin_id, destination_id properties(若干列)],
-                .geo文件中的id顺序应该跟.dyna中一致,
-                其中全局参数`data_col`用于指定需要加载的数据的列，不设置则默认全部加载
+        加载.od文件，格式[dyna_id, type, time, origin_id, destination_id properties(若干列)],
+        .geo文件中的id顺序应该跟.dyna中一致,
+        其中全局参数`data_col`用于指定需要加载的数据的列，不设置则默认全部加载
 
-                Args:
-                    filename(str): 数据文件名，不包含后缀
+        Args:
+            filename(str): 数据文件名，不包含后缀
 
-                Returns:
-                    np.ndarray: 数据数组, 4d-array: (len_time, len_row, len_column, feature_dim)
-                """
+        Returns:
+            np.ndarray: 数据数组, 4d-array: (len_time, len_row, len_column, feature_dim)
+        """
         self._logger.info("Loading file " + filename + '.od')
         odfile = pd.read_csv(self.data_path + filename + '.od')
         if self.data_col != '':  # 根据指定的列加载数据集

--- a/libcity/data/dataset/trajectory_dataset.py
+++ b/libcity/data/dataset/trajectory_dataset.py
@@ -23,7 +23,10 @@ class TrajectoryDataset(AbstractDataset):
         for param in parameter_list:
             self.cut_data_cache += '_' + str(self.config[param])
         self.cut_data_cache += '.json'
-        self.data_path = './raw_data/{}/'.format(self.config['dataset'])
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.dyna_file = self.config.get('dyna_file', self.dataset)
+        self.data_path = './raw_data/{}/'.format(self.dataset)
         self.data = None
         # 加载 encoder
         self.encoder = self.get_encoder()
@@ -97,7 +100,7 @@ class TrajectoryDataset(AbstractDataset):
         """
         # load data according to config
         traj = pd.read_csv(os.path.join(
-            self.data_path, '{}.dyna'.format(self.config['dataset'])))
+            self.data_path, '{}.dyna'.format(self.dyna_file)))
         # filter inactive poi
         group_location = traj.groupby('location').count()
         filter_location = group_location[group_location['time'] >= self.config['min_checkins']]

--- a/libcity/data/dataset/trajectory_encoder/atstlstm_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/atstlstm_encoder.py
@@ -33,8 +33,10 @@ class AtstlstmEncoder(AbstractTrajectoryEncoder):
                 parameters_str += '_' + str(self.config[key])
         self.cache_file_name = os.path.join(
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
-        self.data_path = './raw_data/{}/'.format(self.config['dataset'])
-        self.geo = pd.read_csv(os.path.join(self.data_path, '{}.geo'.format(self.config['dataset'])))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.data_path = './raw_data/{}/'.format(self.dataset)
+        self.geo = pd.read_csv(os.path.join(self.data_path, '{}.geo'.format(self.geo_file)))
 
     def encode(self, uid, trajectories, negative_sample):
         """Encoded Method refered to the open source code

--- a/libcity/data/dataset/trajectory_encoder/cara_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/cara_encoder.py
@@ -26,7 +26,9 @@ class CARATrajectoryEncoder(AbstractTrajectoryEncoder):
                 parameters_str += '_' + str(self.config[key])
         self.cache_file_name = os.path.join(
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
-        self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.config['dataset'], self.config['dataset']))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.dataset, self.geo_file))
 
     def encode(self, uid, trajectories, negative_sample=None):
         """standard encoder use the same method as DeepMove

--- a/libcity/data/dataset/trajectory_encoder/hstlstm_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/hstlstm_encoder.py
@@ -33,8 +33,10 @@ class HstlstmEncoder(AbstractTrajectoryEncoder):
                 parameters_str += '_' + str(self.config[key])
         self.cache_file_name = os.path.join(
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
-        self.data_path = './raw_data/{}/'.format(self.config['dataset'])
-        self.geo = pd.read_csv(os.path.join(self.data_path, '{}.geo'.format(self.config['dataset'])))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.data_path = './raw_data/{}/'.format(self.dataset)
+        self.geo = pd.read_csv(os.path.join(self.data_path, '{}.geo'.format(self.geo_file)))
 
     def encode(self, uid, trajectories, negative_sample=None):
         """standard encoder use the same method as DeepMove

--- a/libcity/data/dataset/trajectory_encoder/lstpm_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/lstpm_encoder.py
@@ -43,7 +43,9 @@ class LstpmEncoder(AbstractTrajectoryEncoder):
                 parameters_str += '_' + str(self.config[key])
         self.cache_file_name = os.path.join(
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
-        self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.config['dataset'], self.config['dataset']))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.dataset, self.geo_file))
         self.time_checkin_set = defaultdict(set)
 
     def encode(self, uid, trajectories, negative_sample=None):

--- a/libcity/data/dataset/trajectory_encoder/serm_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/serm_encoder.py
@@ -34,9 +34,11 @@ class SermEncoder(AbstractTrajectoryEncoder):
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
         # load poi_profile
         self.poi_profile = None
-        if self.config['dataset'] in ['foursquare_tky', 'foursquare_nyk', 'foursquare_serm']:
-            self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.config['dataset'],
-                                                                         self.config['dataset']))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        if self.dataset in ['foursquare_tky', 'foursquare_nyk', 'foursquare_serm']:
+            self.poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.dataset,
+                                                                         self.geo_file))
 
     def encode(self, uid, trajectories, negative_sample=None):
         """standard encoder use the same method as DeepMove
@@ -134,7 +136,7 @@ class SermEncoder(AbstractTrajectoryEncoder):
         """
             return word index
         """
-        if self.config['dataset'] in ['foursquare_tky', 'foursquare_nyk', 'foursquare_serm']:
+        if self.dataset in ['foursquare_tky', 'foursquare_nyk', 'foursquare_serm']:
             # 语义信息在 geo 表中
             words = self.poi_profile.iloc[point[4]]['venue_category_name'].split(' ')
             word_index = []

--- a/libcity/data/dataset/trajectory_encoder/stan_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/stan_encoder.py
@@ -145,7 +145,9 @@ class StanEncoder(AbstractTrajectoryEncoder):
         return time.hour + time.weekday() * 24 + 1
 
     def _cal_poi_matrix(self):
-        poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.config['dataset'], self.config['dataset']))
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        poi_profile = pd.read_csv('./raw_data/{}/{}.geo'.format(self.dataset, self.geo_file))
         mat = np.zeros((self.loc_id-1, self.loc_id-1))
         for i in tqdm(range(1, self.loc_id), desc='calculate poi distance matrix'):
             lon_i, lat_i = parse_coordinate(poi_profile.iloc[self.id2location[i]]['coordinates'])

--- a/libcity/data/dataset/trajectory_encoder/strnn_encoder.py
+++ b/libcity/data/dataset/trajectory_encoder/strnn_encoder.py
@@ -26,7 +26,9 @@ class StrnnEncoder(AbstractTrajectoryEncoder):
             './libcity/cache/dataset_cache/', 'trajectory_{}.json'.format(parameters_str))
 
         self.geo_coord = {}
-        path = "./raw_data/{}/{}.geo".format(config['dataset'], config['dataset'])
+        self.dataset = self.config.get('dataset', '')
+        self.geo_file = self.config.get('geo_file', self.dataset)
+        path = "./raw_data/{}/{}.geo".format(self.dataset, self.geo_file)
         f_geo = open(path)
         lines = f_geo.readlines()
 


### PR DESCRIPTION
为了跟前端的代码适配，也跟其他几个任务统一，ETA和下一跳两个任务读取数据做了一点变化。
主要是允许数据集目录的名字和原子文件的名字不一样。

- dataset---数据集文件夹名字
- geo_file--geo文件名字，不指定的话默认为dataset
- rel_file--rel文件名字，不指定的话默认为dataset
- usr_file--usr文件名字，不指定的话默认为dataset（代码没用到usr文件？）
- dyna_file--dyna文件名字，不指定的话默认为dataset

默认从数据集config.json中的`info`键指定，设置geo_file、rel_file、dyna_file=dataset