### PR TITLE
The loss of STSGCN is irregularly large

### DIFF
--- a/libcity/config/model/traffic_state_pred/STSGCN.json
+++ b/libcity/config/model/traffic_state_pred/STSGCN.json
@@ -13,6 +13,8 @@
   ],
   "rho": 1,
   "bidir_adj_mx": true,
+  "batch_size": 32,
+  "distance_inverse": true,
 
   "scaler": "standard",
   "load_external": true,

--- a/libcity/data/dataset/traffic_state_datatset.py
+++ b/libcity/data/dataset/traffic_state_datatset.py
@@ -175,7 +175,7 @@ class TrafficStateDataset(AbstractDataset):
                     self.adj_mx[self.geo_to_ind[row[1]], self.geo_to_ind[row[0]]] = 1
         self._logger.info("Loaded file " + self.rel_file + '.rel, shape=' + str(self.adj_mx.shape))
         # 计算权重
-        if self.distance_inverse:
+        if self.distance_inverse and self.set_weight_link_or_dist.lower() != 'link':
             self._distance_inverse()
         elif self.calculate_weight_adj and self.set_weight_link_or_dist.lower() != 'link':
             self._calculate_adjacency_matrix()


### PR DESCRIPTION
I am currently testing the STSGCN and found the loss is irregularly large (>1e10).
I read the code and found the output is accumulated after the graph convolution:
https://github.com/LibCity/Bigscity-LibCity/blob/85d13516132894d7b7d1665891bc18194dfa5f13/libcity/model/traffic_flow_prediction/STSGCN.py#L50
I checked the paper and code and thought they use the distance inverse as the adjacent matrix, rather than the Gauss kernel (https://github.com/Davidham3/STSGCN/blob/master/utils.py#L105). 
```
    # Fills cells in the matrix with distances.
    with open(distance_df_filename, 'r') as f:
        f.readline()
        reader = csv.reader(f)
        for row in reader:
            if len(row) != 3:
                continue
            i, j, distance = int(row[0]), int(row[1]), float(row[2])
            if type_ == 'connectivity':
                A[i, j] = 1
                A[j, i] = 1
            elif type == 'distance':
                A[i, j] = 1 / distance
                A[j, i] = 1 / distance
            else:
                raise ValueError("type_ error, must be "
                                 "connectivity or distance!")
    return A
```
I added a new function in traffic_state_dataset to calculate the distance inverse for STSGCN and the loss now looks reasonable
(PEMSD7(M), 12 prediction steps):
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/huson/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/huson/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->

</head>

<body link="#0563C1" vlink="#954F72">



MAE | MAPE | MSE | RMSE | masked_MAE | masked_MAPE | masked_MSE | masked_RMSE | R2 | EVAR
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1.461792 | 0.033766 | 6.305071 | 2.51099 | 1.461792 | 0.033766 | 6.305071 | 2.51099 | 0.966612 | 0.967362
1.886784 | 0.044624 | 12.02078 | 3.4671 | 1.886784 | 0.044624 | 12.02078 | 3.4671 | 0.936329 | 0.937318
2.208205 | 0.05365 | 17.84879 | 4.224782 | 2.208205 | 0.05365 | 17.84879 | 4.224782 | 0.90546 | 0.907067
2.445271 | 0.060798 | 23.0774 | 4.803894 | 2.445271 | 0.060798 | 23.0774 | 4.803894 | 0.877856 | 0.879756
2.636102 | 0.067311 | 27.92206 | 5.284132 | 2.636102 | 0.067311 | 27.92206 | 5.284132 | 0.852311 | 0.854849
2.793431 | 0.072273 | 32.20569 | 5.675005 | 2.793431 | 0.072273 | 32.20569 | 5.675005 | 0.829672 | 0.8325
2.914345 | 0.076151 | 35.48109 | 5.956601 | 2.914345 | 0.076151 | 35.48109 | 5.956601 | 0.812326 | 0.815592
3.017157 | 0.079508 | 38.48553 | 6.203671 | 3.017157 | 0.079508 | 38.48553 | 6.203671 | 0.796511 | 0.799579
3.103143 | 0.082126 | 40.83116 | 6.389926 | 3.103143 | 0.082126 | 40.83116 | 6.389926 | 0.784075 | 0.786962
3.165864 | 0.084001 | 42.70291 | 6.534747 | 3.165864 | 0.084001 | 42.70291 | 6.534747 | 0.774234 | 0.776773
3.236152 | 0.086049 | 44.63507 | 6.680949 | 3.236152 | 0.086049 | 44.63507 | 6.680949 | 0.763969 | 0.766483
3.298688 | 0.087792 | 46.06493 | 6.787116 | 3.298688 | 0.087792 | 46.06493 | 6.787116 | 0.756369 | 0.75932



</body>

</html>
