### PR TITLE
[fix] extend SSTBAN input/output dim from 1 to data dim

### DIFF
--- a/libcity/data/dataset/dataset_subclass/sstban_dataset.py
+++ b/libcity/data/dataset/dataset_subclass/sstban_dataset.py
@@ -15,7 +15,7 @@ def seq2instance_plus(data, num_his, num_pred):
     y = []
     for i in range(num_sample):
         x.append(data[i: i + num_his])
-        y.append(data[i + num_his: i + num_his + num_pred, :, :1])
+        y.append(data[i + num_his: i + num_his + num_pred])
     x = np.array(x)
     y = np.array(y)
     return x, y
@@ -73,7 +73,7 @@ class SSTBANDataset(TrafficStatePointDataset):
         te = {}
         for set_name in data_sets.keys():
             data_set = data_sets[set_name]
-            x, y = seq2instance_plus(data_set[..., :1].astype("float64"), self.input_window, self.output_window)
+            x, y = seq2instance_plus(data_set[..., :self.output_dim].astype("float64"), self.input_window, self.output_window)
             xy[set_name] = [x, y]
             # handle te
             te_set = te_sets[set_name]


### PR DESCRIPTION
调整SSTBAN数据集输入/输出维度从固定值1为数据本身维度/output_dim

已在NYCBike1/NYCTaxi/BJTaxi上进行测试

问题：目前SSTBAN的配置文件中有in_channels和out_channels两个参数，实际对应了模型的输入维度和输出维度，建议将这两个与feature_dim/output_dim参数合并