### PR TITLE
fix:HIEST适应多维输入，将双联通向量搜寻从递归改为循环

### DIFF
--- a/libcity/data/dataset/dataset_subclass/hiest_dataset.py
+++ b/libcity/data/dataset/dataset_subclass/hiest_dataset.py
@@ -39,6 +39,52 @@ class Graph:
                rooted with current vertex
     st -- >> To store visited edges'''
 
+    def BCCUtilLoop(self, u, parent, low, disc, st):
+        stack = [(u, self.graph[u], 0, False, -1)]
+
+        while stack:
+            u, g, children, flag, v = stack.pop(-1)
+            if flag:
+                # Check if the subtree rooted with v has a connection to
+                # one of the ancestors of u
+                # Case 1 -- per Strongly Connected Components Article
+                low[u] = min(low[u], low[v])
+
+                # If u is an articulation point, pop
+                # all edges from stack till (u, v)
+                if parent[u] == -1 and children > 1 or parent[u] != -1 and low[v] >= disc[u]:
+                    self.count += 1  # increment count
+                    w = -1
+                    tmp = []
+                    while w != (u, v):
+                        w = st.pop()
+                        tmp.append(w)
+                    self.res.append(tmp)
+            disc[u] = self.Time
+            low[u] = self.Time
+            self.Time += 1
+            while g:
+                v = g.pop(0)
+                # If v is not visited yet, then make it a child of u
+                # in DFS tree and recur for it
+                if disc[v] == -1:
+                    parent[v] = u
+                    children += 1
+                    st.append((u, v))  # store the edge in stack
+                    stack.append((u, g, children, True, v))
+                    stack.append((v, self.graph[v], 0, False, -1))
+                    break
+
+                elif v != parent[u] and low[u] > disc[v]:
+                    '''Update low value of 'u' only of 'v' is still in stack
+                    (i.e. it's a back edge, not cross edge).
+                    Case 2
+                    -- per Strongly Connected Components Article'''
+
+                    low[u] = min(low[u], disc[v])
+
+                    st.append((u, v))
+
     def BCCUtil(self, u, parent, low, disc, st):
 
         # Count of children in current node
@@ -103,12 +149,12 @@ class Graph:
         # in DFS tree rooted with vertex 'i'
         for i in range(self.V):
             if disc[i] == -1:
-                self.BCCUtil(i, parent, low, disc, st)
+                self.BCCUtilLoop(i, parent, low, disc, st)
 
             # If stack is not empty, pop all edges from stack
             if st:
                 self.count = self.count + 1
-                tmp=[]
+                tmp = []
                 while st:
                     w = st.pop()
                     tmp.append(w)
@@ -172,6 +218,6 @@ class HIESTDataset(TrafficStatePointDataset):
         Returns:
             dict: 包含数据集的相关特征的字典
         """
-        return {"scaler": self.scaler, "adj_mx": self.adj_mx ,"ext_dim": self.ext_dim,
-                "num_nodes": self.num_nodes, "feature_dim": self.feature_dim,"regional_nodes": self.regional_nodes,
-                "Mor_mx": self.Mor_mx,"output_dim": self.output_dim, "num_batches": self.num_batches}
+        return {"scaler": self.scaler, "adj_mx": self.adj_mx, "ext_dim": self.ext_dim,
+                "num_nodes": self.num_nodes, "feature_dim": self.feature_dim, "regional_nodes": self.regional_nodes,
+                "Mor_mx": self.Mor_mx, "output_dim": self.output_dim, "num_batches": self.num_batches}

--- a/libcity/model/traffic_speed_prediction/HIEST.py
+++ b/libcity/model/traffic_speed_prediction/HIEST.py
@@ -201,7 +201,7 @@ class HIEST(AbstractTrafficStateModel):
         # adaptive layer numbers
         self.apt_layer = config.get('apt_layer', True)
         if self.apt_layer:
-            self.layers = np.int(
+            self.layers = np.int64(
                 np.round(np.log((((self.input_window - 1) / (self.blocks * (self.kernel_size - 1))) + 1)) / np.log(2)))
             print('# of layers change to %s' % self.layers)
 
@@ -359,8 +359,7 @@ class HIEST(AbstractTrafficStateModel):
         The implementation of L_{ort}
         '''
         # hr = (batch_size, end_channels, num_nodes, self.output_dim)
-        hr = hr.squeeze(3)
-        hr = hr.permute(2, 0, 1)
+        hr = hr.permute(2, 0, 1, 3)
         hr = torch.reshape(hr, (self.global_nodes, -1))
         # print('hr.size')
         # print(hr.size())


### PR DESCRIPTION

NYCTaxi2015| 递归 | 循环 
-- | -- | -- | --
MAE | 10.8993 | 10.4972
RMSE | 24.1007 | 23.0964
MAPE | 0.3964 | 0.3936

NYCTaxi2016| 递归 | 循环 
-- | -- | -- | --
MAE | 9.6159 | 9.2664
RMSE | 21.2956 | 20.6347
MAPE | 0.4873 | 0.4614

NYCTaxi2016| 递归 | 循环 
-- | -- | -- | --
MAE | 9.6159 | 9.2664
RMSE | 21.2956 | 20.6347
MAPE | 0.4873 | 0.4614
